### PR TITLE
Use API from signalhub > v4.0.0

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@ var wrtc = require('wrtc')
 var signalhub = require('signalhub')
 var swarm = require('./')
 
-var sw = swarm(signalhub('dev.mathiasbuus.eu:8080', 'swarm-example'), {
+var sw = swarm(signalhub('swarm-example', 'dev.mathiasbuus.eu:8080'), {
   wrtc: wrtc
 })
 


### PR DESCRIPTION
Updates `example.js` to use the latest signalhub API.

I had to start my own signalhub locally to get the example working (and downgrade `cuid` because of https://github.com/ericelliott/cuid/issues/42)
