### PR TITLE
Choose UUID + Wrap/Unwrap Signaling Data

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (hub, opts) {
 
   var swarm = new events.EventEmitter()
   var remotes = {}
-  var me = cuid()
+  var me = opts.uuid || cuid()
   debug('my uuid:', me)
 
   swarm.maxPeers = opts.maxPeers || Infinity
@@ -57,6 +57,10 @@ module.exports = function (hub, opts) {
     debug('/all', data)
     if (data.from === me) {
       debug('skipping self', data.from)
+      return cb()
+    }
+    if (opts.whitelist && opts.whitelist.indexOf(data.from) === -1) {
+      debug('skipping not whitelisted peer', data.from)
       return cb()
     }
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var debug = require('debug')('webrtc-swarm')
 
 module.exports = function (hub, opts) {
   if (!opts) opts = {}
-  var wrap = opts.wrap || function (dat) { return dat }
-  var unwrap = opts.unwrap || function (dat) { return dat }
+  var wrap = opts.wrap || function (data) { return data }
+  var unwrap = opts.unwrap || function (data) { return data }
 
   var swarm = new events.EventEmitter()
   var remotes = {}


### PR DESCRIPTION
Added generic wrapping and unwrapping functions and the ability to manually set the UUID.
Together that can be used to implement a whitelist and/or encryption of the signaling data.

After playing around a while mainly trying to authenticate peers and encrypt signaling data this seems to be the most generic but still workable implementation.

New options at one glance:

``` js
opts = {
  uuid: 'string',
  wrap: function (data, channel),
  unwrap: function (data, channel)  // if return value falsy: data gets dropped
}
```

There is no debug message when `unwrap` fails. I thought that message can/should be thrown by the unwrap function itself.

All changes are backward compatible.
