### PR TITLE
Signalhub is a necessary dependency in order to run the example

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "simple-peer": "^5.1.0",
     "through2": "^2.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "signalhub": "^4.3.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mafintosh/webrtc-swarm.git"


### PR DESCRIPTION
I'm not sure if it's customary to include dependencies for examples in devDependencies, but if so, here it is.
