### PR TITLE
Deferred emission of stream events received before emitting connect event

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ function subscribe (swarm, hub) {
         stream: swarm.stream,
         offerConstraints: swarm.offerConstraints
       })
+      peer.on('stream', function (stream) { peer.stream = stream; })
 
       setup(swarm, peer, data.from)
       swarm.remotes[data.from] = peer
@@ -162,6 +163,7 @@ function subscribe (swarm, hub) {
         stream: swarm.stream,
         offerConstraints: swarm.offerConstraints
       })
+      peer.on('stream', function (stream) { peer.stream = stream; })
 
       setup(swarm, peer, data.from)
     }


### PR DESCRIPTION
Fix #25 

This is an initial draft of the solution. Since `simple-peer` has no support for lazy-adding streams, let's store the stream sent by the peer inside the peer.