### PR TITLE
Document wrap function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ you if not supplied.
 - `maxPeers` - (optional) the maximum number of peers you wish to connect to.
 Defaults to unlimited.
 - `wrap` - (optional) a function that can modify the WebRTC signaling data
-before it gets send out. Signature: `wrap(outgoingSignalingData,
-destinationSignalhubChannel)`
+before it gets send out. It's called  with `wrap(outgoingSignalingData,
+destinationSignalhubChannel)` and must return the modified signaling data.
 - `unwrap` - (optional) a function that can modify the WebRTC signaling data
-before it gets processed. Signature: `unwrap(incomingSignalingData,
-sourceSignalhubChannel)`
+before it gets processed. It's called  with `unwrap(incomingSignalingData,
+sourceSignalhubChannel)` and must return the modified signaling data.
 
 Additional optional keys can be passed through to the underlying
 [simple-peer](https://www.npmjs.com/package/simple-peer) instances:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ you if not supplied.
 Defaults to unlimited.
 - `wrap` - (optional) a function that can modify the WebRTC signaling data
 before it gets send out. It's called  with `wrap(outgoingSignalingData,
-destinationSignalhubChannel)` and must return the modified signaling data.
+destinationSignalhubChannel)` and must return the wrapped signaling data.
 - `unwrap` - (optional) a function that can modify the WebRTC signaling data
 before it gets processed. It's called  with `unwrap(incomingData,
 sourceSignalhubChannel)` and must return the raw signaling data.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Valid keys for `opts` include:
 you if not supplied.
 - `maxPeers` - (optional) the maximum number of peers you wish to connect to.
 Defaults to unlimited.
+- `wrap` - (optional) a function that can modify the WebRTC signaling data
+before it gets send out. Signature: `wrap(outgoingSignalingData,
+destinationSignalhubChannel)`
+- `unwrap` - (optional) a function that can modify the WebRTC signaling data
+before it gets processed. Signature: `unwrap(incomingSignalingData,
+sourceSignalhubChannel)`
 
 Additional optional keys can be passed through to the underlying
 [simple-peer](https://www.npmjs.com/package/simple-peer) instances:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Defaults to unlimited.
 before it gets send out. It's called  with `wrap(outgoingSignalingData,
 destinationSignalhubChannel)` and must return the modified signaling data.
 - `unwrap` - (optional) a function that can modify the WebRTC signaling data
-before it gets processed. It's called  with `unwrap(incomingSignalingData,
-sourceSignalhubChannel)` and must return the modified signaling data.
+before it gets processed. It's called  with `unwrap(incomingData,
+sourceSignalhubChannel)` and must return the raw signaling data.
 
 Additional optional keys can be passed through to the underlying
 [simple-peer](https://www.npmjs.com/package/simple-peer) instances:


### PR DESCRIPTION
 ```
README.md
...
  - `maxPeers` - (optional) the maximum number of peers you wish to connect to.
  Defaults to unlimited.
 +- `wrap` - (optional) a function that can modify the WebRTC signaling data
 +before it gets send out. It's called  with `wrap(outgoingSignalingData,
 +destinationSignalhubChannel)` and must return the modified signaling data.
 +- `unwrap` - (optional) a function that can modify the WebRTC signaling data
 +before it gets processed. It's called  with `unwrap(incomingSignalingData,
 +sourceSignalhubChannel)` and must return the modified signaling data.
```