### PR TITLE
use local signalhub; rename variables to match usage in libs

### DIFF
--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ server.listen(9000, function () {
     var sw1 = swarm(hub1, {wrtc})
     var sw2 = swarm(hub2, {wrtc})
 
-    var greeting = 'hello'
+    var hello = 'hello'
     var goodbye = 'goodbye'
 
     var peerIds = {}
@@ -27,7 +27,7 @@ server.listen(9000, function () {
     sw1.on('peer', function (peer, id) {
       t.pass('connected to peer from sw2')
       peerIds.sw2 = id
-      peer.send(greeting)
+      peer.send(hello)
       peer.on('data', function (data) {
         t.equal(data.toString(), goodbye, 'goodbye received')
         sw1.close(function () {
@@ -40,7 +40,7 @@ server.listen(9000, function () {
       t.pass('connected to peer from sw1')
       peerIds.sw1 = id
       peer.on('data', function (data) {
-        t.equal(data.toString(), greeting, 'greeting received')
+        t.equal(data.toString(), hello, 'hello received')
         peer.send(goodbye)
         sw2.close(function () {
           t.pass('swarm sw2 closed')

--- a/test.js
+++ b/test.js
@@ -1,52 +1,47 @@
-var tape = require('tape')
+var server = require('signalhub/server')()
 var signalhub = require('signalhub')
 var swarm = require('./')
+var test = require('tape')
 var wrtc = require('electron-webrtc')()
-var crypto = require('crypto')
 
-tape('greet and close', function (t) {
-  t.plan(6)
-
-  var peer1 = swarm(signalhub(randomHex('64'), 'https://signalhub.mafintosh.com'), {wrtc})
-  var peer2 = swarm(signalhub(randomHex('64'), 'https://signalhub.mafintosh.com'), {wrtc})
-
-  var greeting = 'peer 1 says hello'
-  var goodbye = 'peer 2 says goodbye'
-
-  peer1.on('peer', function (peer, id) {
-    t.ok(1, 'peer 1 joined by ' + id)
-    peer.send(greeting)
-    peer.on('data', function (c) {
-      t.equal(c.toString(), goodbye, 'goodbye received')
-      peer1.close(function () {
-        t.ok(1, 'peer 1 closed')
-        if (wrtc) wrtc.close()
-      })
-    })
-  })
-
-  peer2.on('peer', function (peer, id) {
-    t.ok(1, 'peer 2 joined by', id)
-    peer.on('data', function (c) {
-      t.equal(c.toString(), greeting, 'greeting received')
-      peer.send(goodbye)
-      peer2.close(function () {
-        t.ok(1, 'peer 2 closed')
-      })
-    })
-  })
-
-  peer1.on('disconnect', function (peer, id) {
-    t.comment('peer 1 disconnected from ' + id)
-  })
-
-  peer2.on('disconnect', function (peer, id) {
-    t.comment('peer 2 disconnected from ' + id)
-  })
+test.onFinish(function () {
+  server.close()
+  wrtc.close()
 })
 
-function randomHex (len) {
-  return crypto.randomBytes(Math.ceil(len / 2))
-         .toString('hex') // convert to hexadecimal format
-         .slice(0, len)   // return required number of characters
-}
+server.listen(9000, function () {
+  test('greet and close', function (t) {
+    t.plan(6)
+
+    var hub1 = signalhub('app', 'localhost:9000')
+    var hub2 = signalhub('app', 'localhost:9000')
+
+    var sw1 = swarm(hub1, {wrtc})
+    var sw2 = swarm(hub2, {wrtc})
+
+    var greeting = 'hello'
+    var goodbye = 'goodbye'
+
+    sw1.on('peer', function (peer, id) {
+      t.pass('peer from sw2 joined')
+      peer.send(greeting)
+      peer.on('data', function (data) {
+        t.equal(data.toString(), goodbye, 'goodbye received')
+        sw1.close(function () {
+          t.pass('sw1 closed')
+        })
+      })
+    })
+
+    sw2.on('peer', function (peer, id) {
+      t.pass('peer from sw1 joined')
+      peer.on('data', function (data) {
+        t.equal(data.toString(), greeting, 'greeting received')
+        peer.send(goodbye)
+        sw2.close(function () {
+          t.pass('sw2 closed')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Use a local signalhub instance like the test of signalhub does
- Rename variables in accordance with the code snippets in the respective repos
- fixes #19 ("tests hang and don't complete")
- fix `.on('disconnect'` tests. They failed on multiple successive test runs because of obsolete `disconnect` events.