### PR TITLE
update cuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "standard && tape test.js"
   },
   "dependencies": {
-    "cuid": "^1.2.4",
+    "cuid": "^2.1.0",
     "debug": "^2.2.0",
     "inherits": "^2.0.1",
     "once": "^1.3.1",


### PR DESCRIPTION
Hello! 

When packaging with browserify (via bankai/choo), we're running into a strange error in the browser:

```
Cannot read property 'applitude' of undefined
```

This looks like its related to the `cuid` package. A newer version of this package was released to resolve this issue.

This PR updates to the new version of `cuid` which resolves this error.
