### PR TITLE
Upgrade dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function setup (swarm, peer, id) {
   function kick () {
     if (swarm.closed || sending || !signals.length) return
     sending = true
-    var data = {from: swarm.me, signal: signals.shift()}
+    var data = { from: swarm.me, signal: signals.shift() }
     data = swarm.wrap(data, id)
     swarm.hub.broadcast(id, data, function () {
       sending = false
@@ -174,7 +174,7 @@ function subscribe (swarm, hub) {
 
 function connect (swarm, hub) {
   if (swarm.closed || swarm.peers.length >= swarm.maxPeers) return
-  var data = {type: 'connect', from: swarm.me}
+  var data = { type: 'connect', from: swarm.me }
   data = swarm.wrap(data, 'all')
   hub.broadcast('all', data, function () {
     setTimeout(connect.bind(null, swarm, hub), Math.floor(Math.random() * 2000) + (swarm.peers.length ? 13000 : 3000))

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "test": "standard && tape test.js"
   },
   "dependencies": {
-    "cuid": "^1.2.4",
-    "debug": "^2.2.0",
+    "cuid": "^2.1.4",
+    "debug": "^4.1.0",
     "inherits": "^2.0.1",
     "once": "^1.3.1",
-    "simple-peer": "^6.0.1",
-    "through2": "^2.0.0"
+    "simple-peer": "^9.2.0",
+    "through2": "^3.0.0"
   },
   "devDependencies": {
-    "electron-webrtc": "^0.2.6",
+    "electron-webrtc": "^0.3.0",
     "signalhub": "^4.7.1",
-    "standard": "^7.1.2",
+    "standard": "^12.0.1",
     "tape": "^4.6.0"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -16,8 +16,8 @@ server.listen(9000, function () {
     var hub1 = signalhub('app', 'localhost:9000')
     var hub2 = signalhub('app', 'localhost:9000')
 
-    var sw1 = swarm(hub1, {wrtc})
-    var sw2 = swarm(hub2, {wrtc})
+    var sw1 = swarm(hub1, { wrtc })
+    var sw2 = swarm(hub2, { wrtc })
 
     var hello = 'hello'
     var goodbye = 'goodbye'


### PR DESCRIPTION
Upgrade `simple-peer` dependency to `9.2.0`. This is needed to make this library work on Safari `12.0 (14606.1.36.1.9)` - see https://github.com/feross/simple-peer/issues/190 and https://github.com/feross/simple-peer/pull/337.

While I was at it I also upgraded other dependencies (and reformatted code according to latest `standard`). 

This PR supersedes #33