### PR TITLE
Update simple-peer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "^2.2.0",
     "inherits": "^2.0.1",
     "once": "^1.3.1",
-    "simple-peer": "^6.0.1",
+    "simple-peer": "^9.7.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I was not able to use peer.addStream with the lower version. Can you update simple-peer?