### PR TITLE
Add 'peer-connecting' event so simple-peer's 'track' events can be delivered, & ES6 changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sw.on('disconnect', function (peer, id) {
 ## API
 
 ```js
-var swarm = require('webrtc-swarm')
+let swarm = require('webrtc-swarm')
 ```
 
 ### var sw = swarm(hub, opts)
@@ -70,6 +70,10 @@ constructor)
 ### sw.close()
 
 Disconnect from swarm
+
+### sw.on('peer-connecting', peer, id)
+
+Fires when a connection is being established to a new peer `peer`, with unique id `id`.
 
 ### sw.on('peer|connect', peer, id)
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var SimplePeer = require('simple-peer')
-var inherits = require('inherits')
-var events = require('events')
-var through = require('through2')
-var cuid = require('cuid')
-var once = require('once')
-var debug = require('debug')('webrtc-swarm')
+const SimplePeer = require('simple-peer')
+const inherits = require('inherits')
+const events = require('events')
+const through = require('through2')
+const cuid = require('cuid')
+const once = require('once')
+const debug = require('debug')('webrtc-swarm')
 
 module.exports = WebRTCSwarm
 
@@ -45,11 +45,11 @@ WebRTCSwarm.prototype.close = function (cb) {
 
   if (cb) this.once('close', cb)
 
-  var self = this
+  const self = this
   this.hub.close(function () {
-    var len = self.peers.length
+    const len = self.peers.length
     if (len > 0) {
-      var closed = 0
+      let closed = 0
       self.peers.forEach(function (peer) {
         peer.once('close', function () {
           if (++closed === len) {
@@ -67,6 +67,11 @@ WebRTCSwarm.prototype.close = function (cb) {
 }
 
 function setup (swarm, peer, id) {
+  /* emit peer and connect events as soon as peers are available
+   * to allow stream negotiation  */
+  swarm.emit('peer', peer, id)
+  swarm.emit('connect', peer, id)
+  swarm.peers.push(peer)
   peer.on('connect', function () {
     debug('connected to peer', id)
     swarm.peers.push(peer)
@@ -74,21 +79,21 @@ function setup (swarm, peer, id) {
     swarm.emit('connect', peer, id)
   })
 
-  var onclose = once(function (err) {
+  const onclose = once(function (err) {
     debug('disconnected from peer', id, err)
     if (swarm.remotes[id] === peer) delete swarm.remotes[id]
-    var i = swarm.peers.indexOf(peer)
+    const i = swarm.peers.indexOf(peer)
     if (i > -1) swarm.peers.splice(i, 1)
     swarm.emit('disconnect', peer, id)
   })
 
-  var signals = []
-  var sending = false
+  const signals = []
+  let sending = false
 
   function kick () {
     if (swarm.closed || sending || !signals.length) return
     sending = true
-    var data = {from: swarm.me, signal: signals.shift()}
+    let data = { from: swarm.me, signal: signals.shift() }
     data = swarm.wrap(data, id)
     swarm.hub.broadcast(id, data, function () {
       sending = false
@@ -100,7 +105,6 @@ function setup (swarm, peer, id) {
     signals.push(sig)
     kick()
   })
-
   peer.on('error', onclose)
   peer.once('close', onclose)
 }
@@ -127,7 +131,7 @@ function subscribe (swarm, hub) {
       }
 
       debug('connecting to new peer (as initiator)', data.from)
-      var peer = new SimplePeer({
+      const peer = new SimplePeer({
         wrtc: swarm.wrtc,
         initiator: true,
         channelConfig: swarm.channelConfig,
@@ -147,7 +151,7 @@ function subscribe (swarm, hub) {
     data = swarm.unwrap(data, swarm.me)
     if (swarm.closed || !data) return cb()
 
-    var peer = swarm.remotes[data.from]
+    let peer = swarm.remotes[data.from]
     if (!peer) {
       if (!data.signal || data.signal.type !== 'offer') {
         debug('skipping non-offer', data)
@@ -174,7 +178,7 @@ function subscribe (swarm, hub) {
 
 function connect (swarm, hub) {
   if (swarm.closed || swarm.peers.length >= swarm.maxPeers) return
-  var data = {type: 'connect', from: swarm.me}
+  let data = { type: 'connect', from: swarm.me }
   data = swarm.wrap(data, 'all')
   hub.broadcast('all', data, function () {
     setTimeout(connect.bind(null, swarm, hub), Math.floor(Math.random() * 2000) + (swarm.peers.length ? 13000 : 3000))

--- a/index.js
+++ b/index.js
@@ -67,11 +67,10 @@ WebRTCSwarm.prototype.close = function (cb) {
 }
 
 function setup (swarm, peer, id) {
-  /* emit peer and connect events as soon as peers are available
-   * to allow stream negotiation  */
-  swarm.emit('peer', peer, id)
-  swarm.emit('connect', peer, id)
-  swarm.peers.push(peer)
+  /* emit peer-connecting events as soon as
+   * peers are available to allow delivery
+   * of 'track' events  */
+  swarm.emit('peer-connecting', peer, id)
   peer.on('connect', function () {
     debug('connected to peer', id)
     swarm.peers.push(peer)

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
   "name": "webrtc-swarm",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Create a swarm of p2p connections using webrtc and a signalhub",
   "main": "index.js",
   "scripts": {
     "test": "standard && tape test.js"
   },
   "dependencies": {
-    "cuid": "^1.2.4",
-    "debug": "^2.2.0",
-    "inherits": "^2.0.1",
-    "once": "^1.3.1",
-    "simple-peer": "^6.0.1",
-    "through2": "^2.0.0"
+    "cuid": "^2.1.8",
+    "debug": "^4.1.1",
+    "inherits": "^2.0.4",
+    "npm-check-updates": "^4.1.2",
+    "once": "^1.4.0",
+    "simple-peer": "^9.6.2",
+    "through2": "^3.0.1"
   },
   "devDependencies": {
-    "electron-webrtc": "^0.2.6",
-    "signalhub": "^4.7.1",
-    "standard": "^7.1.2",
-    "tape": "^4.6.0"
+    "electron-webrtc": "^0.3.0",
+    "signalhub": "^4.9.0",
+    "standard": "^14.3.3",
+    "tape": "^4.13.2"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -16,8 +16,8 @@ server.listen(9000, function () {
     var hub1 = signalhub('app', 'localhost:9000')
     var hub2 = signalhub('app', 'localhost:9000')
 
-    var sw1 = swarm(hub1, {wrtc})
-    var sw2 = swarm(hub2, {wrtc})
+    var sw1 = swarm(hub1, { wrtc })
+    var sw2 = swarm(hub2, { wrtc })
 
     var hello = 'hello'
     var goodbye = 'goodbye'


### PR DESCRIPTION
This adds a new `peer-connecting` event.  This is emitted as soon as peers are available, so simple-peer's `track` events are delivered.

(Also, some ES6 changes.)